### PR TITLE
Add max_width and max_height to yaml file

### DIFF
--- a/example/merge.yaml
+++ b/example/merge.yaml
@@ -1,3 +1,6 @@
+max_width: 100
+max_height: 1000
+boards:
 - board: main.kicad_pcb
   qty: 1
   margin_mm: 2      # default = 1

--- a/example/panelize.bat
+++ b/example/panelize.bat
@@ -2,9 +2,9 @@
 
 set input_yaml=merge.yaml
 
-kikit panelize \
-  --layout "plugin; code: ../kikit-packer.py.Plugin; input:%input_yaml%" \
-    --tabs "fixed; hwidth: 2mm; vwidth: 2mm" \
-    --cuts "mousebites" \
-    --post "millradius: 1mm" \
+kikit panelize ^
+  --layout "plugin; code: ../kikit-packer.py.Plugin; input:%input_yaml%" ^
+    --tabs "fixed; hwidth: 2mm; vwidth: 2mm" ^
+    --cuts "mousebites" ^
+    --post "millradius: 1mm" ^
   main.kicad_pcb combined.kicad_pcb

--- a/kikit-packer.py
+++ b/kikit-packer.py
@@ -50,8 +50,14 @@ class Plugin(LayoutPlugin):
 
         import yaml
         with open(input_yaml, 'r') as file:
-            input_boards = yaml.safe_load(file)
+            yaml_data = yaml.safe_load(file)
+
+        input_boards = yaml_data['boards']
         print(input_boards)
+
+        max_width = yaml_data['max_width'] * mm if 'max_width' in yaml_data else None
+        max_height = yaml_data['max_height'] * mm if 'max_height' in yaml_data else None
+        print(f"max_height: {max_height}, max_width: {max_width}")
 
         panel.sourcePaths.add(mainInputFile)
 
@@ -97,7 +103,7 @@ class Plugin(LayoutPlugin):
             boards.extend([board] * count)
             filenames.extend([filename] * count)
 
-        best_rotates, best_positions = optimal_pack(sizes, max_width=None, max_height=None)
+        best_rotates, best_positions = optimal_pack(sizes, max_width=max_width, max_height=max_height)
 
         print(best_rotates, best_positions)
 


### PR DESCRIPTION
As I needed the packed PCB to be in a certain maximum width to fit into my reflow oven, I implented the following changes. This would allow you to specify max_width and height in the yaml file. I hope this is helpful for others as well, 

Additionally, the .bat file for the example needed `^` at the line breaks to work properly. 

I tested it with my PCBs and the example and it seems to work. 