### PR TITLE
Fix: use ceiling division for eps scaling instead of strict assert

### DIFF
--- a/kikit-packer.py
+++ b/kikit-packer.py
@@ -91,14 +91,9 @@ class Plugin(LayoutPlugin):
 
             bbox = expandRect(findBoardBoundingBox(board), margin)
 
-            assert (bbox.GetWidth() + self.hspace) % S == 0, (
-                f"Board width+hspace ({bbox.GetWidth()}+{self.hspace}) is not multiple of {S}")
-            assert (bbox.GetHeight() + self.vspace) % S == 0, (
-                f"Board height+vspace ({bbox.GetHeight()}+{self.vspace}) is not multiple of {S}")
-
             sizes.extend([(
-                int((bbox.GetWidth() + self.hspace) / S),
-                int((bbox.GetHeight() + self.vspace) / S)
+                -(-int(bbox.GetWidth() + self.hspace) // S),
+                -(-int(bbox.GetHeight() + self.vspace) // S)
             )] * count)
 
             boards.extend([board] * count)


### PR DESCRIPTION
## Summary
- The strict `assert (width) % S == 0` fails for any board with non-round nanometer dimensions, which is virtually all real boards
- Since `eps` is needed to scale nanometer values down to a range `rectangle-packer` can handle, this effectively makes the `eps` parameter unusable
- Replaced with ceiling integer division (`-(-x // S)`), which rounds up slightly — safe because it just adds a tiny bit of extra spacing per board

## Context
Without `eps > 1`, boards of typical size (~70mm = 69,500,271 nm) cause "Rectangle area too large" from the rectangle-packer library. But setting `eps` to any useful value (e.g. 100000) triggers the assert because 69,500,271 is not an exact multiple of 100,000.

The existing `# TODO use math.gcd` comment suggests this was a known limitation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)