### PR TITLE
Fix: scale max_width/max_height by eps to match board size units

### DIFF
--- a/kikit-packer.py
+++ b/kikit-packer.py
@@ -104,7 +104,9 @@ class Plugin(LayoutPlugin):
             boards.extend([board] * count)
             filenames.extend([filename] * count)
 
-        best_rotates, best_positions = optimal_pack(sizes, max_width=max_width, max_height=max_height)
+        pack_max_w = -(-int(max_width) // S) if max_width is not None else None
+        pack_max_h = -(-int(max_height) // S) if max_height is not None else None
+        best_rotates, best_positions = optimal_pack(sizes, max_width=pack_max_w, max_height=pack_max_h)
 
         print(best_rotates, best_positions)
 


### PR DESCRIPTION
## Summary
- Board sizes are divided by `eps` before being passed to `rectangle-packer`, but `max_width` and `max_height` are passed in raw nanometers
- This unit mismatch makes the constraints effectively useless when `eps > 1`

## Example
With `eps=100000` and `max_width=300` (mm):
- Board of 70mm is scaled to ~716 packer units
- `max_width` stays at 300,000,000 (raw nanometers) — **418,994x** larger than the board
- The constraint has no practical effect

With the fix, `max_width` is also scaled to ~3000 packer units, giving the correct 4.2x ratio.

🤖 Generated with [Claude Code](https://claude.com/claude-code)