### PR TITLE
Enable bakeText to resolve text variables per-board

### DIFF
--- a/kikit-packer.py
+++ b/kikit-packer.py
@@ -118,6 +118,7 @@ class Plugin(LayoutPlugin):
                 refRenamer=refRenamer,
                 rotationAngle=self.rotation + pcbnew.EDA_ANGLE((90 if best_rotates[i] else 0), pcbnew.DEGREES_T),
                 inheritDrc=False,
+                bakeText=True,
             )
 
         print('Done.')


### PR DESCRIPTION
## Summary
- Passes `bakeText=True` to `appendBoard()` (an existing KiKit parameter that defaults to `False`)

## Why this should be the default for a multi-board packer
When panelizing different boards, KiCad text variables like `${TITLE}` and `${REVISION}` all resolve from the panel's project settings, which are inherited from the first/reference board. This means every board in the panel displays the same title and revision, regardless of what its own title block says.

Since the whole point of kikit-packer is combining *different* boards into one panel, it's almost always wrong for them to share text variable values. `bakeText=True` resolves each board's variables from its own title block before placement, so a panel of "PCB-004 rev A" and "PCB-005 rev B" correctly shows each board's own label.

This is a one-line change flipping an existing KiKit default — no new functionality, just a more sensible default for multi-board panelization.

🤖 Generated with [Claude Code](https://claude.com/claude-code)